### PR TITLE
Fix KeyError for conflicting flag

### DIFF
--- a/check_lint.py
+++ b/check_lint.py
@@ -86,7 +86,7 @@ class SublimeHaskellHsDevChain(CommandWin.BackendTextCommand):
         output_messages = [ParseOutput.OutputMessage(m['source']['file'],
                                                      HsResultParse.parse_region(m['region']).to_zero_based(),
                                                      m['level'].capitalize() + ': ' + m['note']['message'].replace('\n', '\n  '),
-                                                     m['level']) for m in self.msgs]
+                                                     m['level']) for m in self.msgs if 'file' in m['source']]
 
         self.corrections = corrections or []
         for corr in self.corrections:


### PR DESCRIPTION
HLint will complain if a source file specifies a conflicting `-Ox` compiler flag, such as `{-# OPTIONS_GHC -O2 #-}`. However, the `source` key is just an empty object in this case and will give a `KeyError`:
```javascript
{
  'level': 'warning',
  'note': {
    'message': '-O conflicts with --interactive; -O ignored.',
    'suggestion': None
  },
  'region': {
    'from': {
      'column': 0,
      'line': 0
    },
    'to': {
      'column': 0,
      'line': 0
    }
  },
  'source': {
  }
}
```